### PR TITLE
Update config to reflect latest meeting's changes (legacy)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: node_js
 node_js:
-- '5'
+- '6'
 - '4'
 - '0.12'
-- '0.11'
 - '0.10'
 deploy:
   provider: npm

--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@ This package provides OpenTable's .eslintrc as an extensible shared config. We e
 
 ## Usage
 
-We export three ESLint configurations for your usage.
-
 The export lints ES6/2015+. It requires `eslint`.
 
 1. `npm install --save-dev eslint-config-opentable eslint`
@@ -15,19 +13,24 @@ See [Airbnb's Javascript styleguide](https://github.com/airbnb/javascript) and
 the [ESlint config docs](http://eslint.org/docs/user-guide/configuring#extending-configuration-files)
 for more information.
 
-## Major differences
+## Differences
 
-The main difference between this config and airbnb's is that we have adopted
-a more Coffeescript-like syntax as we begin the transfer from Coffeescript to ES6.
+There are a few minor differences between this config and AirBnB's. Links are to AirBnB's styleguide.
 
-- Semicolons must be excluded. JS developers should understand Automatic Semicolon Insertion rules whether semicolons are used or not.
-  For more info, see [An Open Letter to JavaScript Leaders Regarding Semicolons](http://blog.izs.me/post/2353458699/an-open-letter-to-javascript-leaders-regarding)
-  and [Everything You Need to Know About ASI](http://inimino.org/~inimino/blog/javascript_semicolon).
-  Fortunately, eslint should warn when it looks like a semicolon is required, but it doesn't happen often.
-- Double quotes instead of single.
-- Console logs are allowed.
-- Double equals (`==`) is permitted for one special case: `== null`. This allows you to determine equality with `undefined` and/or `null` in one statement.
-- Function names are not required in function expressions.
-- Nested ternaries are allowed.
-- Comma dangle is turned off.
-- While we still enforce the capitalization convention when using `new`, we've included a very common capitalized factory function exception that should not be used with `new`: `$.Deferred`.
+- [15.1](https://github.com/airbnb/javascript#comparison--eqeqeq) eqeqeq (prefer `===` to `==`) - **Yes, but with "allow-null" turned on**
+
+  > Why? Comparing to both `null` and `undefined` can be done succinctly with `== null`.
+  This is now enabled in AirBnB's config as well, but the style guide has not been updated.
+
+- [18.12](https://github.com/airbnb/javascript#whitespace--max-len) Max line length: 100 - **Increased to 120**
+
+  > Why? We just wanted to allow longer lines.
+
+- [19.2](https://github.com/airbnb/javascript#commas--dangling) Comma dangle - **No**
+
+  > Why? We found the extra comma distracting.
+
+- [22.3](https://github.com/airbnb/javascript#naming--PascalCase) Use PascalCase only when naming constructors or classes. - **Yes, but one exception**
+
+  > Why? We added $.Deferred as a common exception, since it should not be used with the `new` keyword.
+

--- a/index.js
+++ b/index.js
@@ -1,24 +1,45 @@
 module.exports = {
-  extends: require.resolve("eslint-config-airbnb-base"),
+  extends: require.resolve('eslint-config-airbnb-base'),
   rules: {
-    "comma-dangle": [2, "never"],
-    eqeqeq: [2, "allow-null"],
-    "func-names": 0,
-    indent: [2, 2, { SwitchCase: 1 }],
-    "max-len": [1, 120],
-    "new-cap": [2, {
-      capIsNewExceptions: ["$.Deferred"]
+
+    // Disallow comma-dangle
+    // http://eslint.org/docs/rules/comma-dangle
+    'comma-dangle': [2, 'never'],
+
+    // require the use of === and !==
+    // allow == null
+    // http://eslint.org/docs/rules/eqeqeq
+    eqeqeq: [2, 'allow-null'],
+
+    // Neither required nor prohibited
+    // AirBnB used to enable this, but since
+    // changed their rule to prefer
+    // function declarations and arrow functions
+    // to avoid function expressions.
+    // There's no difference here, just a precaution.
+    // http://eslint.org/docs/rules/func-names
+    'func-names': 0,
+
+    // specify the maximum length of a line
+    // http://eslint.org/docs/rules/max-len
+    'max-len': [2, {
+      code: 120,
+      tabWidth: 2,
+      ignoreComments: true,
+      ignoreUrls: true
     }],
-    "no-cond-assign": [2, "except-parens"],
-    "no-console": 0,
-    "no-nested-ternary": 0,
-    "one-var": [2, {
-      uninitialized: "always",
-      initialized: "never"
+
+    // Adds $.Deferred as an exception to the new-cap
+    // rule, since it should not be used with new
+    // http://eslint.org/docs/rules/new-cap
+    'new-cap': [2, {
+      capIsNewExceptions: ['$.Deferred']
     }],
-    "one-var-declaration-per-line": 0,
-    quotes: [2, "double", "avoid-escape"],
-    semi: [2, "never"],
-    "space-before-function-paren": [2, "never"]
+
+    // A minor difference for assignments in a conditional expression
+    // Instead of setting to ''always'', parenthesis make an assignment explicit
+    // This is not explained in the AirBnB style guide either
+    // http://eslint.org/docs/rules/no-cond-assign
+    'no-cond-assign': [2, 'except-parens']
   }
-}
+};

--- a/package.json
+++ b/package.json
@@ -23,9 +23,9 @@
   "homepage": "https://github.com/opentable/eslint-config-opentable",
   "dependencies": {
     "eslint-config-airbnb-base": "^3.0.1",
-    "eslint-plugin-import": "^1.8.1"
+    "eslint-plugin-import": "^1.11.1"
   },
   "devDependencies": {
-    "eslint": "^2.11.1"
+    "eslint": "^2.13.1"
   }
 }

--- a/test/base.js
+++ b/test/base.js
@@ -1,1 +1,1 @@
-export default "base"
+export default 'base';

--- a/test/test.js
+++ b/test/test.js
@@ -1,33 +1,38 @@
 /**
  * This file doesn't actually get run, just linted.
  */
-import fs from "fs"
-import path from "path"
-import base from "./base"
+import fs from 'fs';
+import path from 'path';
+import base from './base';
 
 function test() {}
 
-const files = { base }
+const files = {
+  base,
+  path,
+  fs
+};
 
-fs.readdirSync(path.join(__dirname, "../rules")).forEach(name => {
-  if (name === "react.js") {
-    return
+fs.readdirSync(path.join(__dirname, '../rules')).forEach(name => {
+  if (name === 'react.js') {
+    return;
   }
 
-  files[name] = require(`../rules/${name}`) // eslint-disable-line global-require
-})
+  files[name] = `../rules/${name}`;
+});
 
 Object.keys(files).forEach(name => {
-  const config = files[name]
+  const config = files[name];
 
   test(`${name}: does not reference react`, t => {
-    t.plan(2)
+    t.plan(2);
 
-    t.notOk(config.plugins, "plugins is unspecified")
+    t.notOk(config.plugins, 'plugins is unspecified');
 
     // scan rules for react/ and fail if any exist
     const reactRuleIds = Object.keys(config.rules)
-      .filter(ruleId => ruleId.indexOf("react/") === 0)
-    t.deepEquals(reactRuleIds, [], "there are no react/ rules")
-  })
-})
+      .filter(ruleId => ruleId.indexOf('react/') == null);
+
+    t.deepEquals(reactRuleIds, [], 'there are no react/ rules');
+  });
+});


### PR DESCRIPTION
- Keeps eslint 2.x for a first release.