### PR TITLE
update to latest airbnb-config and eslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,10 +22,10 @@
   },
   "homepage": "https://github.com/opentable/eslint-config-opentable",
   "dependencies": {
-    "eslint-config-airbnb-base": "^7.1.0",
-    "eslint-plugin-import": "^1.15.0"
+    "eslint-config-airbnb-base": "^11.2.0",
+    "eslint-plugin-import": "^2.3.0"
   },
   "devDependencies": {
-    "eslint": "^3.1.1"
+    "eslint": "^3.19.0"
   }
 }


### PR DESCRIPTION
Airbnb has updated their config so that there are no longer errors thrown when requiring a devDependency from paths commonly associated with tests

https://github.com/airbnb/javascript/blob/master/packages/eslint-config-airbnb-base/rules/imports.js#L72-L86

BREAKING CHANGE: I don't know? Probably?