### PR TITLE
[OTPL-6939] updated packages for security updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-- '10'
-- '12'
+- '14'
+- '16'
 deploy:
   provider: npm
   email: ''

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-opentable",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "description": "This package provides OpenTable's .eslintrc as an extensible shared config.",
   "main": "index.js",
   "scripts": {
@@ -25,8 +25,8 @@
   },
   "homepage": "https://github.com/opentable/eslint-config-opentable",
   "dependencies": {
+    "eslint": "7.32.0",
     "eslint-config-airbnb-base": "14.2.1",
-    "eslint-plugin-import": "2.22.1",
-    "eslint": "7.13.0"
+    "eslint-plugin-import": "2.26.0"
   }
 }


### PR DESCRIPTION
This PR modifies the travis build to test against node 14 and 16 (as the officially supported LTS releases)
It also updates packages to help address security issues with `minimist` and `ansi-regex`

Details:
- https://github.com/opentable/ot-logger-nodejs/security/dependabot/10 
- https://github.com/opentable/ot-logger-nodejs/security/dependabot/9
- https://github.com/opentable/ot-logger-nodejs/security/dependabot/8
- https://github.com/opentable/ot-logger-nodejs/security/dependabot/6